### PR TITLE
Bugfix and compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Otherwise:
 
 **Python 3.6+**
 
+**Kubernetes version 1.19+**
+
 Dependencies: See [Dockerfile](Dockerfile)
 
 When deploying to a Kubernetes cluster the `Pod` that `kubernetes-ingress-info` is
@@ -55,7 +57,7 @@ deployed as needs to run as a `serviceAccount` with (at a minimum) a binding to 
 ```
 ...
 rules:
-- apiGroups: ["extensions"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["list"]
 ```

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: bof-ingress-info
 rules:
-- apiGroups: ["extensions"]
+- apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
   verbs: ["list"]
 
@@ -55,7 +55,7 @@ spec:
       serviceAccountName: bof-ingress-info
       containers:
         - name: kubernetes-ingress-info
-          image: bitsofinfo/kubernetes-ingress-info:1.0.3
+          image: bitsofinfo/kubernetes-ingress-info:latest
           ports:
             - name: info-port
               containerPort: 8081
@@ -97,7 +97,7 @@ spec:
     targetPort: info-port
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: bitsofinfo
@@ -107,6 +107,9 @@ spec:
     - host: kubernetes-ingress-info.local
       http:
         paths:
-          - backend:
-              serviceName: kubernetes-ingress-info
-              servicePort: 31311
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: kubernetes-ingress-info
+                port:
+                  number: 31311

--- a/info.py
+++ b/info.py
@@ -33,7 +33,7 @@ class IngressInfo(resource.Resource):
         else:
             config.load_incluster_config()
 
-        self.v1Api = client.ExtensionsV1beta1Api()
+        self.v1Api = client.NetworkingV1Api()
 
     # fetches the Ingress database
     def getIngressDb(self):
@@ -89,8 +89,9 @@ class IngressInfo(resource.Resource):
                 continue;
 
             for r in i.spec.rules:
-                ingressInfo = { 'host':r.host.lower() }
-                ingressDb['unique_hosts'].add(r.host.lower())
+                if r.host is not None:
+                    ingressInfo = { 'host':r.host.lower() }
+                    ingressDb['unique_hosts'].add(r.host.lower())
 
         if self.cache is not None:
             self.cache.set(b'INGRESS_DB', value=ingressDb, expire=self.cache_ttl_seconds)


### PR DESCRIPTION
1.
Bugfix: crashed if ingress object has no 'host':
```
ERROR - render_GET unexpected error: failure: (<class 'AttributeError'>, AttributeError("'NoneType' object has no attribute 'lower'"), <traceback object at 0x7efee267a688>)
Traceback (most recent call last):
  File "/usr/local/bin/info.py", line 107, in render_GET
    ingressDb = self.getIngressDb()
  File "/usr/local/bin/info.py", line 93, in getIngressDb
    ingressInfo = { 'host':r.host.lower() }
AttributeError: 'NoneType' object has no attribute 'lower'
```
2.
Changed API from `extensions` to `networking.k8s.io` which is required for kubernetes 1.22+ and is available since 1.19.

